### PR TITLE
Fix: Enforce chronological ordering of video questions (minimal, 21 lines)

### DIFF
--- a/classroompicker.html
+++ b/classroompicker.html
@@ -4257,10 +4257,12 @@
             const sidebarList = document.getElementById('video-sidebar-list');
             if (!sidebarList) return;
 
+            let qCounter = 0;
             sidebarList.innerHTML = sortedVideoItems.map(item => {
                 const icon = item._kind === 'note' ? '📌' : '❓';
                 const mmss = Math.floor(item.time / 60) + ':' + String(Math.floor(item.time % 60)).padStart(2, '0');
-                const title = item._kind === 'note' ? 'Note' : `Q${item._index + 1}`;
+                if (item._kind !== 'note') qCounter++;
+                const title = item._kind === 'note' ? 'Note' : `Q${qCounter}`;
                 return `<div id="vsb_${item.id}" class="p-3 bg-gray-700/50 border border-gray-600 rounded-lg text-sm mb-2 text-gray-300 transition-colors">
                     <span class="font-bold text-yellow-400 mr-2">${title}</span> 
                     <span class="text-xs text-gray-400 opacity-70">[${mmss}]</span>
@@ -4292,10 +4294,13 @@
                 playerContainer.innerHTML = `<iframe src="https://drive.google.com/file/d/${assignmentData.videoSourceId}/preview" class="w-full h-full" allow="autoplay" frameborder="0" style="position: absolute; top:0; left:0;"></iframe>`;
                 if (sidebarList) {
                     sidebarList.innerHTML = `<p class="text-sm text-gray-400 mb-4 italic p-2 border border-gray-600 rounded">Google Drive videos cannot automatically pause. Please watch the video and answer the questions interactively below.</p>`;
+                    let qCounterDrive = 0;
                     sortedVideoItems.forEach(item => {
                         const existingAnswerHtml = (item._kind === 'question' && slideStates[item._index] && slideStates[item._index].answer) ? `<span class="ml-2 text-green-400 text-xs">✅ Answered</span>` : '';
+                        if (item._kind !== 'note') qCounterDrive++;
+                        const driveTitle = item._kind === 'note' ? '📌 Note' : `❓ Q${qCounterDrive}`;
                         sidebarList.innerHTML += `<div class="mb-4 bg-gray-700/60 border border-gray-600 p-4 rounded-lg shadow-sm">
-                            <p class="text-sm font-bold text-yellow-500 mb-2">${item._kind === 'note' ? '📌 Note' : '❓ Q' + (item._index + 1)} <span class="text-gray-400 text-xs ml-1">[${Math.floor(item.time / 60)}:${String(Math.floor(item.time % 60)).padStart(2, '0')}]</span>${existingAnswerHtml}</p>
+                            <p class="text-sm font-bold text-yellow-500 mb-2">${driveTitle} <span class="text-gray-400 text-xs ml-1">[${Math.floor(item.time / 60)}:${String(Math.floor(item.time % 60)).padStart(2, '0')}]</span>${existingAnswerHtml}</p>
                             <p class="text-sm text-gray-200 mb-3 leading-relaxed">${escapeHtml(item.body)}</p>
                             ${item._kind === 'question' ? `<button onclick="showVideoOverlay('${item.id}', true)" class="w-full bg-blue-600 hover:bg-blue-700 font-bold px-3 py-2 rounded text-sm text-white transition-colors">Answer Question</button>` : ''}
                         </div>`;

--- a/video-editor.html
+++ b/video-editor.html
@@ -1237,6 +1237,10 @@
       const container = document.getElementById('questionsContainer');
       const noMsg = document.getElementById('noQuestionsMsg');
 
+      // Sort source arrays by timestamp to ensure chronological order in memory and storage
+      videoQuestions.sort((a, b) => a.time - b.time);
+      videoNotes.sort((a, b) => a.time - b.time);
+
       // Combine questions and notes
       // We'll use a secondary sort key (array position) to keep order stable for items at same time
       const allItems = [
@@ -1510,7 +1514,7 @@
           document.getElementById('assignmentTitle').textContent = `Editing: ${data.title}`;
         }
 
-        // Import questions
+        // Import questions (without IDs initially, so we can sort first)
         const importedQuestions = (data.questions || []).map(q => {
           const bodyHtml = q.body?.[0]?.html || q.body?.[0]?.text || '';
           const bodyText = stripHtml(bodyHtml);
@@ -1521,7 +1525,6 @@
           const hasMultipleCorrect = choices.filter(c => c.isCorrect).length > 1;
 
           return {
-            id: `vq${nextQId++}`,
             type: 'multiple-choice',
             time: q.time || 0,
             body: bodyText,
@@ -1530,15 +1533,22 @@
           };
         });
 
-        // Import notes
+        // Import notes (without IDs initially, so we can sort first)
         const importedNotes = (data.notes || []).map(n => {
           const bodyHtml = n.body?.[0]?.html || n.body?.[0]?.text || '';
           return {
-            id: `vn${nextNId++}`,
             time: n.time || 0,
             body: stripHtml(bodyHtml)
           };
         });
+
+        // Sort by time before assigning IDs so IDs are in chronological order
+        importedQuestions.sort((a, b) => a.time - b.time);
+        importedNotes.sort((a, b) => a.time - b.time);
+
+        // Now assign IDs in sorted order
+        importedQuestions.forEach(q => q.id = `vq${nextQId++}`);
+        importedNotes.forEach(n => n.id = `vn${nextNId++}`);
 
         videoQuestions.push(...importedQuestions);
         videoNotes.push(...importedNotes);


### PR DESCRIPTION
## Minimal fix: Enforce chronological ordering of video questions and notes

**2 files changed, 21 insertions(+), 6 deletions(-)**

### Problem
When importing questions from EdPuzzle, they could appear out of chronological order. Additionally, question numbering in the student view used the raw array index (`_index + 1`) instead of a sequential counter, so if items were out of order the labels would be wrong.

### Changes

#### `video-editor.html` (+14 / -4)
1. **`renderQuestions()`**: Added 3 lines to sort `videoQuestions` and `videoNotes` arrays by `.time` at the start of every render. This ensures that the in-memory arrays (and therefore the saved data) are always in chronological order.
2. **`handleImport()`**: Changed to create imported items *without* IDs, sort by time, *then* assign IDs (`vq1`, `vq2`...) in chronological order. Previously IDs were assigned in JSON iteration order which could be arbitrary.

#### `classroompicker.html` (+7 / -2)
1. **YouTube sidebar**: Replaced `Q${item._index + 1}` with a local `qCounter` that increments only for questions (not notes), ensuring labels are always sequential: Q1, Q2, Q3...
2. **Google Drive view**: Same counter-based fix for the inline question list shown for Drive videos.