### PR TITLE
Enhance Video Assignments: Navigation Locks and Watch Time Percentages

### DIFF
--- a/classroompicker.html
+++ b/classroompicker.html
@@ -2074,7 +2074,7 @@
 
             //disables question links when hidden
             const postRule = assignmentData.postSubmissionRule || 'open';
-            const shouldDisableLinks = isSubmitted && postRule === 'hide';
+            let shouldDisableLinks = isSubmitted && postRule === 'hide';
 
             const isPDF = assignmentData.type === 'pdf';
             const isVideo = assignmentData.type === 'video';
@@ -2107,11 +2107,22 @@
                     }
                 }
 
+                let disableThisLink = shouldDisableLinks;
+                if (isVideo && assignmentData.videoSourceType === 'youtube') {
+                    const settings = assignmentData.playbackSettings || {};
+                    const qItem = sortedVideoItems.find(it => it._kind === 'question' && it._index === index);
+                    if (qItem) {
+                        const isAhead = settings.skipPrevention && (qItem.time > furthestReachedTime + 1);
+                        const isBehind = settings.preventGoingBack && (qItem.time < furthestReachedTime - 5);
+                        disableThisLink = disableThisLink || isAhead || isBehind;
+                    }
+                }
+
                 const jumpFunc = isVideo ? `jumpToVideoItemByQuestionIndex` : isSimulation ? `jumpToSimulationQuestion` : isBlank ? `jumpToBlankQuestion` : `jumpToSlide`;
-                const clickHandler = shouldDisableLinks ? '' : (isPDF ? `onclick="focusPDFZone(${index})"` : `onclick="${jumpFunc}(${index})"`);
-                const cursorClass = shouldDisableLinks ? 'cursor-not-allowed' : 'cursor-pointer';
-                const hoverClass = shouldDisableLinks ? '' : 'hover:bg-gray-600';
-                const opacityClass = shouldDisableLinks ? 'opacity-50' : '';
+                const clickHandler = disableThisLink ? '' : (isPDF ? `onclick="focusPDFZone(${index})"` : `onclick="${jumpFunc}(${index})"`);
+                const cursorClass = disableThisLink ? 'cursor-not-allowed' : 'cursor-pointer';
+                const hoverClass = disableThisLink ? '' : 'hover:bg-gray-600';
+                const opacityClass = disableThisLink ? 'opacity-50' : '';
                 const questionLabel = isSimulation
                     ? (assignmentData.simQuestions?.[index]?.body || `Question ${index + 1}`)
                     : isBlank
@@ -4440,6 +4451,7 @@
                     studentEmail: userProfile.email.toLowerCase(),
                     watchTime: watchTimeSeconds,
                     furthestReachedTime: furthestReachedTime,
+                    videoDuration: (assignmentData.type === 'video' && typeof videoPlayer !== 'undefined' && videoPlayer && typeof videoPlayer.getDuration === 'function') ? videoPlayer.getDuration() : 0,
                     score: currentAvg,
                     lastAccessed: firebase.firestore.FieldValue.serverTimestamp()
                 }, { merge: true });
@@ -4704,10 +4716,29 @@
         function jumpToVideoItemByQuestionIndex(qIndex) {
             const item = sortedVideoItems.find(it => it._kind === 'question' && it._index === qIndex);
             if (item) {
+                if (assignmentData.videoSourceType === 'youtube') {
+                    const settings = assignmentData.playbackSettings || {};
+                    const preventSkipping = settings.skipPrevention;
+                    const preventGoingBack = settings.preventGoingBack;
+
+                    if (preventSkipping && item.time > furthestReachedTime + 1) {
+                        showToast("Skipping forward is disabled.", { color: 'red' });
+                        return;
+                    }
+                    if (preventGoingBack && item.time < furthestReachedTime - 5) {
+                        showToast("Going back to previous questions is disabled.", { color: 'red' });
+                        return;
+                    }
+                }
+
                 const summary = document.getElementById('summaryContainer');
                 if (summary) summary.classList.add('hidden');
                 const main = document.getElementById('mainContainer');
                 if (main) main.classList.remove('hidden');
+
+                if (assignmentData.videoSourceType === 'youtube' && videoPlayer && typeof videoPlayer.seekTo === 'function') {
+                    videoPlayer.seekTo(item.time);
+                }
 
                 showVideoOverlay(item.id, true);
             }

--- a/dashboard.html
+++ b/dashboard.html
@@ -563,7 +563,9 @@
                                     assignmentId: data.assignmentId,
                                     status: data.status || 'none',
                                     score: typeof data.score === 'number' ? data.score : 0,
-                                    watchTime: data.watchTimeSeconds || data.watchTime || 0
+                                    watchTime: data.watchTimeSeconds || data.watchTime || 0,
+                                    furthestReachedTime: data.furthestReachedTime || 0,
+                                    videoDuration: data.videoDuration || 0
                                 });
                             }
                         });
@@ -691,6 +693,8 @@
                         auraAwarded: auraData.auraAwarded,
                         auraAmount: auraData.auraAmount,
                         watchTime: statusData.watchTime || 0,
+                        furthestReachedTime: statusData.furthestReachedTime || 0,
+                        videoDuration: statusData.videoDuration || 0,
                         questionProgress,
                         simData: simDataByStudentLocal.get(student.email) || null,
                         sectionSubmissions
@@ -1229,7 +1233,12 @@
                     const mins = Math.floor(student.watchTime / 60);
                     const secs = student.watchTime % 60;
                     const watchStr = `${mins}:${String(secs).padStart(2, '0')}`;
-                    watchTimeCell = `<td class="px-2 py-4 whitespace-nowrap text-center text-sm font-mono text-blue-400">${watchStr}</td>`;
+                    let percentStr = '';
+                    if (student.videoDuration > 0) {
+                        const pct = Math.min(100, Math.floor((student.furthestReachedTime / student.videoDuration) * 100));
+                        percentStr = `<br><span class="text-[10px] text-gray-400 font-bold">${pct}%</span>`;
+                    }
+                    watchTimeCell = `<td class="px-2 py-4 whitespace-nowrap text-center text-sm font-mono text-blue-400">${watchStr}${percentStr}</td>`;
                 }
                 let simDataCell = '';
                 if (showSimData && assignmentData.type === 'simulation') {

--- a/video-editor.html
+++ b/video-editor.html
@@ -337,6 +337,11 @@
           <span class="text-lg text-gray-200">Prevent students from skipping & seeking ahead</span>
         </label>
         <label class="flex items-center gap-3 cursor-pointer">
+          <input type="checkbox" id="preventGoingBack"
+            class="w-5 h-5 bg-gray-700 border-gray-600 rounded text-yellow-500 focus:ring-yellow-500">
+          <span class="text-lg text-gray-200">Prevent students from going back (One-way progression)</span>
+        </label>
+        <label class="flex items-center gap-3 cursor-pointer">
           <input type="checkbox" id="lockPlaybackSpeed"
             class="w-5 h-5 bg-gray-700 border-gray-600 rounded text-yellow-500 focus:ring-yellow-500">
           <span class="text-lg text-gray-200">Lock playback speed (No speeding up/slowing down)</span>
@@ -855,8 +860,10 @@
         // Load playback settings
         if (assignmentData.playbackSettings) {
           const skipEl = document.getElementById('preventSkipping');
+          const backEl = document.getElementById('preventGoingBack');
           const speedEl = document.getElementById('lockPlaybackSpeed');
           if (skipEl) skipEl.checked = !!assignmentData.playbackSettings.skipPrevention;
+          if (backEl) backEl.checked = !!assignmentData.playbackSettings.preventGoingBack;
           if (speedEl) speedEl.checked = !!assignmentData.playbackSettings.speedLock;
         }
 
@@ -1607,6 +1614,7 @@
 
         const playbackSettings = {
           skipPrevention: document.getElementById('preventSkipping').checked,
+          preventGoingBack: document.getElementById('preventGoingBack').checked,
           speedLock: document.getElementById('lockPlaybackSpeed').checked
         };
 


### PR DESCRIPTION
This PR implements the requested video assignment improvements:

1. **Close Summary Loophole**: Navigating to a question from the summary screen or sidebar now actively seeks the video player to the correct timestamp, fixing the issue where the video would pause at 0:00.
2. **Prevent Going Back**: Added a new "Prevent students from going back (One-way progression)" setting to the video editor.
3. **Summary Gating**: Implemented UI gating on the summary screen to dynamically disable clicking on questions that are ahead of the student's `furthestReachedTime` (if skip prevention is on), or behind (if prevent going back is on).
4. **Percentage Watch Time**: Updated the assignment tracking to save `videoDuration` and calculate the true watched percentage for the teacher dashboard display.

*(Note: Gating and percentage calculations apply to YouTube videos due to iframe constraints on Google Drive videos).*