### PR TITLE
Fix Blank Editor Canvas Mode Load Bug

### DIFF
--- a/blank-editor.html
+++ b/blank-editor.html
@@ -950,7 +950,7 @@ Reading level: [GRADE LEVEL]</p>
                 const lastMode = assignmentData.lastEditorMode || 'structured';
                 currentMode = lastMode;
                 if (lastMode === 'canvas') {
-                    activateCanvasMode(false);
+                    activateCanvasMode(true);
                 } else {
                     activateStructuredMode();
                 }


### PR DESCRIPTION
This PR fixes a critical bug in the Blank Assignment editor where assignments saved in Canvas Mode would load as blank textareas, potentially leading to accidental data loss. 

It ensures that the canvas textarea is always populated from the block data during initial load. 

Note: This fix was developed just after the previous stabilization PR (#70) was merged.