### PR TITLE
Fix blank assignment Copy Grades (all 0s) and inline checker blocking saves

### DIFF
--- a/classroompicker.html
+++ b/classroompicker.html
@@ -3654,8 +3654,14 @@
             if (block.questionType === 'choice') {
                 score = parseInt(studentAnswer, 10) === block.correctChoiceIndex ? (block.points || 100) : 0;
             } else if (block.inlineChecker) {
-                const passed = evaluateInlineChecker(block.inlineChecker, studentAnswer);
-                score = passed ? (block.inlineChecker.points || block.points || 100) : 0;
+                try {
+                    const passed = evaluateInlineChecker(block.inlineChecker, studentAnswer);
+                    score = passed ? (block.inlineChecker.points || block.points || 100) : 0;
+                } catch (e) {
+                    console.error('Inline checker error for block', block.id, e);
+                    showToast(`Checker error: ${e.message}. Answer saved with score 0.`, { color: 'red' });
+                    score = 0;
+                }
             } else {
                 // Use checkerFunctions keyed by block ID
                 const checkerEntry = checkerFunctionStrings[block.id];

--- a/dashboard.html
+++ b/dashboard.html
@@ -2270,7 +2270,7 @@
             const maxPoints = parseFloat(document.getElementById('maxPoints').value) || 100;
             const decimalPlaces = parseInt(document.getElementById('decimalPlaces').value, 10) || 0;
             const studentsToExport = getCurrentlySortedStudents();
-            const numQuestions = assignmentData.type === 'pdf' ? (assignmentData.questionZones ? assignmentData.questionZones.length : 0) : assignmentData.type === 'video' ? (assignmentData.videoQuestions ? assignmentData.videoQuestions.length : 0) : assignmentData.type === 'simulation' ? (assignmentData.simQuestions ? assignmentData.simQuestions.length : 0) : (assignmentData.slideIds ? assignmentData.slideIds.length : 0);
+            const numQuestions = assignmentData.type === 'pdf' ? (assignmentData.questionZones ? assignmentData.questionZones.length : 0) : assignmentData.type === 'video' ? (assignmentData.videoQuestions ? assignmentData.videoQuestions.length : 0) : assignmentData.type === 'simulation' ? (assignmentData.simQuestions ? assignmentData.simQuestions.length : 0) : assignmentData.type === 'blank' ? (assignmentData.blocks || []).filter(b => b.type === 'question').length : (assignmentData.slideIds ? assignmentData.slideIds.length : 0);
 
             const outputData = studentsToExport.map(student => {
                 const nameParts = student.name.split(' ').filter(Boolean);
@@ -2310,7 +2310,7 @@
 
         function exportToCSV() {
             let csvContent = "\uFEFF"; // Add BOM for Excel UTF-8 support
-            const numQuestions = assignmentData.type === 'pdf' ? (assignmentData.questionZones ? assignmentData.questionZones.length : 0) : assignmentData.type === 'video' ? (assignmentData.videoQuestions ? assignmentData.videoQuestions.length : 0) : assignmentData.type === 'simulation' ? (assignmentData.simQuestions ? assignmentData.simQuestions.length : 0) : (assignmentData.slideIds ? assignmentData.slideIds.length : 0);
+            const numQuestions = assignmentData.type === 'pdf' ? (assignmentData.questionZones ? assignmentData.questionZones.length : 0) : assignmentData.type === 'video' ? (assignmentData.videoQuestions ? assignmentData.videoQuestions.length : 0) : assignmentData.type === 'simulation' ? (assignmentData.simQuestions ? assignmentData.simQuestions.length : 0) : assignmentData.type === 'blank' ? (assignmentData.blocks || []).filter(b => b.type === 'question').length : (assignmentData.slideIds ? assignmentData.slideIds.length : 0);
             const hasFocusMode = assignmentData.focusModeEnabled;
 
             let headers = ["Email", "Last Name", "First Name", "Full Name (Last, First)", "Class", "Average Score %", "Completion %"];


### PR DESCRIPTION
## Summary
Fixes two bugs affecting blank assignments:

### Bug 1: Copy Grades exports all 0s for blank assignments
**Root Cause:** `copyGrades()` and `exportToCSV()` in `dashboard.html` computed `numQuestions` using a ternary chain that handled `pdf`, `video`, and `simulation` — but **not `blank`**. Since blank assignments don't have `slideIds`, `numQuestions` resolved to 0, causing every student's grade to export as 0.

**Fix:** Added `assignmentData.type === 'blank' ? (assignmentData.blocks || []).filter(b => b.type === 'question').length` to both functions, matching the pattern already used in `calculateAllClassAverages()`.

### Bug 2: Inline checker errors prevent answer from saving
**Root Cause:** In `classroompicker.html`, the inline checker evaluation in `blankCheckAndSave()` had **no try-catch**. If the checker threw an error, the entire function exited before reaching the Firestore save. The adjacent checker-function code path already had proper error handling.

**Fix:** Wrapped the inline checker evaluation in a try-catch. On error, the answer is still saved with `score = 0` and the student sees a clear error message.

### Note on GSI FedCM console error
The `[GSI_LOGGER]: FedCM get() rejects with AbortError` console message is a known, harmless Google Sign-In library issue — not a bug in our code. No fix needed.